### PR TITLE
for live555 rtsp server, rtp keep alive require must add Session in h…

### DIFF
--- a/format/rtsp/client.go
+++ b/format/rtsp/client.go
@@ -199,6 +199,9 @@ func (self *Client) SendRtpKeepalive() (err error) {
 				Method: "OPTIONS",
 				Uri:    self.requestUri,
 			}
+			if self.session != "" {
+				req.Header = append(req.Header, "Session: "+self.session)
+			}
 			if err = self.WriteRequest(req); err != nil {
 				return
 			}


### PR DESCRIPTION
for live555 rtsp server, rtp keep alive require must add Session in header

this is resolve the issue:
https://github.com/deepch/RTSPtoWebRTC/issues/23