### PR TITLE
Handle 302, handle another stream index

### DIFF
--- a/format/rtsp/client.go
+++ b/format/rtsp/client.go
@@ -310,12 +310,42 @@ func (self *Client) handleResp(res *Response) (err error) {
 			self.session = fields[0]
 		}
 	}
+	if res.StatusCode == 302 {
+		if err = self.handle302(res); err != nil {
+			return
+		}
+	}
 	if res.StatusCode == 401 {
 		if err = self.handle401(res); err != nil {
 			return
 		}
 	}
 	return
+}
+
+func (self *Client) handle302(res *Response) (err error) {
+	/*
+		RTSP/1.0 200 OK
+		CSeq: 302
+	*/
+	newLocation := res.Headers.Get("Location")
+	fmt.Printf("\tRedirecting stream to other location: %s\n", newLocation)
+
+	err = self.Close()
+	if err != nil {
+		return err
+	}
+
+	newConnect, err := Dial(newLocation)
+	if err != nil {
+		return err
+	}
+
+	self.requestUri = newLocation
+	self.conn = newConnect.conn
+	self.brconn = newConnect.brconn
+
+	return err
 }
 
 func (self *Client) handle401(res *Response) (err error) {

--- a/format/rtsp/sdp/parser.go
+++ b/format/rtsp/sdp/parser.go
@@ -110,7 +110,10 @@ func Parse(content string) (sess Session, medias []Media) {
 					}
 				}
 
+			default:
+				media = nil
 			}
+
 		}
 	}
 	return

--- a/format/ts/muxer.go
+++ b/format/ts/muxer.go
@@ -14,8 +14,9 @@ import (
 var CodecTypes = []av.CodecType{av.H264, av.AAC}
 
 type Muxer struct {
-	w                        io.Writer
-	streams                  []*Stream
+	w       io.Writer
+	streams map[int]*Stream
+
 	PaddingToMakeCounterCont bool
 
 	psidata []byte
@@ -42,7 +43,7 @@ func NewMuxer(w io.Writer) *Muxer {
 	}
 }
 
-func (self *Muxer) newStream(codec av.CodecData) (err error) {
+func (self *Muxer) newStream(idx int, codec av.CodecData) (err error) {
 	ok := false
 	for _, c := range CodecTypes {
 		if codec.Type() == c {
@@ -55,14 +56,14 @@ func (self *Muxer) newStream(codec av.CodecData) (err error) {
 		return
 	}
 
-	pid := uint16(len(self.streams) + 0x100)
+	pid := uint16(idx + 0x100)
 	stream := &Stream{
 		muxer:     self,
 		CodecData: codec,
 		pid:       pid,
 		tsw:       tsio.NewTSWriter(pid),
 	}
-	self.streams = append(self.streams, stream)
+	self.streams[idx] = stream
 	return
 }
 
@@ -140,10 +141,11 @@ func (self *Muxer) WritePATPMT() (err error) {
 }
 
 func (self *Muxer) WriteHeader(streams []av.CodecData) (err error) {
-	self.streams = []*Stream{}
-	for _, stream := range streams {
-		if err = self.newStream(stream); err != nil {
-			return
+	self.streams = map[int]*Stream{}
+
+	for idx, stream := range streams {
+		if err = self.newStream(idx, stream); err != nil {
+			fmt.Println(err)
 		}
 	}
 
@@ -154,10 +156,14 @@ func (self *Muxer) WriteHeader(streams []av.CodecData) (err error) {
 }
 
 func (self *Muxer) WritePacket(pkt av.Packet) (err error) {
-	if int(pkt.Idx) >= len(self.streams) {
-		return fmt.Errorf("Wrong stream index: %d", pkt.Idx)
+	var stream *Stream = nil
+
+	stream, ok := self.streams[int(pkt.Idx)]
+	if !ok {
+		fmt.Printf("Warning, unsupported stream index: %d\n", pkt.Idx)
+		return
 	}
-	stream := self.streams[pkt.Idx]
+
 	pkt.Time += time.Second
 
 	switch stream.Type() {

--- a/format/ts/muxer.go
+++ b/format/ts/muxer.go
@@ -154,6 +154,9 @@ func (self *Muxer) WriteHeader(streams []av.CodecData) (err error) {
 }
 
 func (self *Muxer) WritePacket(pkt av.Packet) (err error) {
+	if int(pkt.Idx) >= len(self.streams) {
+		return fmt.Errorf("Wrong stream index: %d", pkt.Idx)
+	}
 	stream := self.streams[pkt.Idx]
 	pkt.Time += time.Second
 


### PR DESCRIPTION
Just added:
1) handling of 302 code (redirecting)
2) default block in case/switch statement
3) handle panic errors for non-existing packet index (also moved from slices to map for indices)