### PR TITLE
missleading nil media

### DIFF
--- a/format/rtsp/sdp/parser.go
+++ b/format/rtsp/sdp/parser.go
@@ -47,6 +47,8 @@ func Parse(content string) (sess Session, medias []Media) {
 						if len(mfields) >= 3 {
 							media.PayloadType, _ = strconv.Atoi(mfields[2])
 						}
+					default:
+						media = nil
 					}
 				}
 
@@ -110,8 +112,6 @@ func Parse(content string) (sess Session, medias []Media) {
 					}
 				}
 
-			default:
-				media = nil
 			}
 
 		}


### PR DESCRIPTION
I've made a mistake setting media = nil in wrong place (this causes to appear error like Fix Format may be raw PCM 97)
After this fix I don't see fatal error anymore.