### PR TITLE
mutext on ts/muxer and get_parameter for keep alive

### DIFF
--- a/format/rtsp/client.go
+++ b/format/rtsp/client.go
@@ -197,7 +197,7 @@ func (self *Client) SendRtpKeepalive() (err error) {
 				fmt.Println("rtp: keep alive")
 			}
 			req := Request{
-				Method: "OPTIONS",
+				Method: "GET_PARAMETER",
 				Uri:    self.requestUri,
 			}
 			if self.session != "" {

--- a/format/ts/muxer.go
+++ b/format/ts/muxer.go
@@ -3,6 +3,7 @@ package ts
 import (
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/deepch/vdk/av"
@@ -14,9 +15,9 @@ import (
 var CodecTypes = []av.CodecType{av.H264, av.AAC}
 
 type Muxer struct {
-	w       io.Writer
-	streams map[int]*Stream
-
+	w                        io.Writer
+	streams                  map[int]*Stream
+	mutex                    sync.Mutex
 	PaddingToMakeCounterCont bool
 
 	psidata []byte
@@ -63,6 +64,10 @@ func (self *Muxer) newStream(idx int, codec av.CodecData) (err error) {
 		pid:       pid,
 		tsw:       tsio.NewTSWriter(pid),
 	}
+
+	defer self.mutex.Unlock()
+	self.mutex.Lock()
+
 	self.streams[idx] = stream
 	return
 }


### PR DESCRIPTION
1. Set method as "GET_PARAMETER"
For cheap or old cameras "OPTIONS" caused no reconnect

2. Add mutex on ts/muxer.go
Working with map concurrently. So sync.Mutex has to be there anyways for thread-safe.