### PR TITLE
Separate control and track with a `/`

### DIFF
--- a/format/rtspv2/client.go
+++ b/format/rtspv2/client.go
@@ -224,6 +224,9 @@ func (client *RTSPClient) ControlTrack(track string) string {
 	if strings.Contains(track, "rtsp://") {
 		return track
 	}
+	if !strings.HasSuffix(client.control, "/") {
+		track = "/" + track
+	}
 	return client.control + track
 }
 


### PR DESCRIPTION
For example, if `client.control` is `rtsp://192.168.1.81:554/live`, `track` is `track0`, the current code will return `rtsp://192.168.1.81:554/livetrack0`, which is incorrect. This PR adds a slash between `live` and `track` to make things work.