### PR TITLE
Fix SDP parsing PCMA and PCMU

### DIFF
--- a/format/rtsp/sdp/parser.go
+++ b/format/rtsp/sdp/parser.go
@@ -101,6 +101,10 @@ func Parse(content string) (sess Session, medias []Media) {
 								media.Type = av.H265
 							case "HEVC":
 								media.Type = av.H265
+							case "PCMA":
+								media.Type = av.PCM_ALAW
+							case "PCMU":
+								media.Type = av.PCM_MULAW
 							}
 							if i, err := strconv.Atoi(keyval[1]); err == nil {
 								media.TimeScale = i


### PR DESCRIPTION
Works fine without fix:

```
m=audio 0 RTP/AVP 8
b=AS:64
a=control:trackID=1
a=rtpmap:8 PCMA/8000/1
a=ptime:125
a=fmtp:8
```

or

```
m=audio 0 RTP/AVP 97
c=IN IP4 0.0.0.0
b=AS:168
a=rtpmap:97 OPUS/48000
a=fmtp:97 
a=control:track2
```

or

```
m=audio 0 RTP/AVP 97
c=IN IP4 0.0.0.0
b=AS:168
a=rtpmap:97 L16/16000
a=fmtp:97 
a=control:track2
```

Don't work without fix:

```
m=audio 0 RTP/AVP 97
c=IN IP4 0.0.0.0
b=AS:168
a=rtpmap:97 PCMU/16000
a=fmtp:97 
a=control:track2
```