### PR TITLE
Adds support SDP Plan B fallback

### DIFF
--- a/format/webrtcv3/adapter.go
+++ b/format/webrtcv3/adapter.go
@@ -93,7 +93,9 @@ func (element *Muxer) WriteHeader(streams []av.CodecData, sdp64 string) (string,
 		Type: webrtc.SDPTypeOffer,
 		SDP:  string(sdpB),
 	}
-	peerConnection, err := element.NewPeerConnection(webrtc.Configuration{})
+	peerConnection, err := element.NewPeerConnection(webrtc.Configuration{
+		SDPSemantics: webrtc.SDPSemanticsUnifiedPlanWithFallback,
+	})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
https://webkit.org/blog/8672/on-the-road-to-webrtc-1-0-including-vp8/

This is fix support iOS 11-12. Without this fix only iOS 13+ supported