### PR TITLE
fix rtsp AAC division error

### DIFF
--- a/format/rtspv2/client.go
+++ b/format/rtspv2/client.go
@@ -736,7 +736,7 @@ func (client *RTSPClient) RTPDemuxer(payloadRAW *[]byte) ([]*av.Packet, bool) {
 					if _, _, _, _, err := aacparser.ParseADTSHeader(frame); err == nil {
 						frame = frame[7:]
 					}
-					duration = time.Duration((float32(1024)/float32(client.AudioTimeScale))*1000) * time.Millisecond
+					duration = time.Duration((float32(1024)/float32(client.AudioTimeScale))*1000*1000*1000) * time.Nanosecond
 					client.AudioTimeLine += duration
 					retmap = append(retmap, &av.Packet{
 						Data:            frame,


### PR DESCRIPTION
AudioTimeScale = 48000
1. duration = time.Duration((float32(1024)/float32(AudioTimeScale)) * 1000) * time.Millisecond = 21ms
    ts = int64(duration * time.Duration(AudioTimeScale) / time.Second) = 1008
2. duration = time.Duration((float32(1024)/float32(AudioTimeScale)) * 1000 * 1000) * time.Microsecond =  21.333ms
    ts = int64(duration * time.Duration(AudioTimeScale) / time.Second) = 1023
3. duration = time.Duration((float32(1024)/float32(AudioTimeScale)) * 1000 * 1000 * 1000) * time.Nanosecond = 21.333334ms
    ts = int64(duration * time.Duration(AudioTimeScale) / time.Second) = 1024
