### PR TITLE
Skip RTCP packets when these are multiplexed on the same port.

### DIFF
--- a/format/rtspv2/client.go
+++ b/format/rtspv2/client.go
@@ -38,8 +38,11 @@ const (
 )
 
 const (
-	RTPHeaderSize = 12
+	RTPHeaderSize      = 12
+	RTCPSenderReport   = 200
+	RTCPReceiverReport = 201
 )
+
 const (
 	DESCRIBE = "DESCRIBE"
 	OPTIONS  = "OPTIONS"
@@ -558,6 +561,11 @@ func (client *RTSPClient) RTPDemuxer(payloadRAW *[]byte) ([]*av.Packet, bool) {
 	SequenceNumber := int(binary.BigEndian.Uint16(content[6:8]))
 	timestamp := int64(binary.BigEndian.Uint32(content[8:16]))
 
+	if isRTCPPacket(content) {
+		client.Println("skipping RTCP packet")
+		return nil, false
+	}
+
 	offset := RTPHeaderSize
 
 	end := len(content)
@@ -949,4 +957,9 @@ func binSize(val int) []byte {
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf, uint32(val))
 	return buf
+}
+
+func isRTCPPacket(content []byte) bool {
+	rtcpPacketType := content[5]
+	return rtcpPacketType == RTCPSenderReport || rtcpPacketType == RTCPReceiverReport
 }


### PR DESCRIPTION
Whithout this change, the packet is miss interpretted as a valid one and
breaks packet sequence as well as duration computation from prev.
packet timestamp.

Following description here https://www.rfc-editor.org/rfc/rfc5761#section-4.
The second header byte is the best way to discriminate RTP data stream
from RTCP packets. This change only focuses on the common scenario of
Senders and Receiver report packets. Other RTCP packets are more
ambiguous as they potentially conflict with payload types.