### PR TITLE
Allow empty ice servers list

### DIFF
--- a/format/webrtcv3/adapter.go
+++ b/format/webrtcv3/adapter.go
@@ -65,10 +65,6 @@ func (element *Muxer) NewPeerConnection(configuration webrtc.Configuration) (*we
 			Credential:     element.Options.ICECredential,
 			CredentialType: webrtc.ICECredentialTypePassword,
 		})
-	} else {
-		configuration.ICEServers = append(configuration.ICEServers, webrtc.ICEServer{
-			URLs: []string{"stun:stun.l.google.com:19302"},
-		})
 	}
 	m := &webrtc.MediaEngine{}
 	if err := m.RegisterDefaultCodecs(); err != nil {


### PR DESCRIPTION
This commit solves this problem:
https://github.com/deepch/RTSPtoWeb/issues/338