### PR TITLE
rtsp: prioritise digest authentication

### DIFF
--- a/format/rtspv2/client.go
+++ b/format/rtspv2/client.go
@@ -418,6 +418,12 @@ func (client *RTSPClient) request(method string, customHeaders map[string]string
 				if splits[0] == "Content-length" {
 					splits[0] = "Content-Length"
 				}
+				if val, ok := res[splits[0]]; ok {
+					if splits[0] == "WWW-Authenticate" && strings.Contains(val, "Digest") && strings.Contains(splits[1], "Basic") {
+						// prioritise digest authentication
+						continue
+					}
+				}
 				res[splits[0]] = splits[1]
 			}
 		}


### PR DESCRIPTION
This pull request solves a problem with security cameras that send both basic and digest realms, prioritising digest authentication.