### PR TITLE
Add RegEx check for Percent Encoding when rtspv2.Dial

### DIFF
--- a/format/rtspv2/client.go
+++ b/format/rtspv2/client.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -521,6 +522,11 @@ func (client *RTSPClient) parseURL(rawURL string) error {
 	}
 	username := l.User.Username()
 	password, _ := l.User.Password()
+	pattern := `[ !#$%&'()*+,/:;=?@\[\]]`
+	re := regexp.MustCompile(pattern)
+	if re.MatchString(username) || re.MatchString(password) {
+		return errors.New("please url encode username and password")
+	}
 	l.User = nil
 	if l.Port() == "" {
 		l.Host = fmt.Sprintf("%s:%s", l.Host, "554")


### PR DESCRIPTION
Related to #26 

This code makes user to QueryEscape their username and password before input their url in rtspv2.Dial method