### PR TITLE
fix: set default port 322 for rtsps scheme in RTSP URL parser

### DIFF
--- a/format/rtspv2/client.go
+++ b/format/rtspv2/client.go
@@ -663,7 +663,12 @@ func (client *RTSPClient) parseURL(rawURL string) error {
 	password, _ := l.User.Password()
 	l.User = nil
 	if l.Port() == "" {
-		l.Host = fmt.Sprintf("%s:%s", l.Host, "554")
+		switch l.Scheme {
+		case "rtsps":
+			l.Host = fmt.Sprintf("%s:%s", l.Host, "322")
+		default:
+			l.Host = fmt.Sprintf("%s:%s", l.Host, "554")
+		}
 	}
 	if l.Scheme != "rtsp" && l.Scheme != "rtsps" {
 		l.Scheme = "rtsp"


### PR DESCRIPTION
Updated the RTSP URL parser to assign the default port 322 for the rtsps scheme.
Port 322 is the official standard port for RTSPS.