### PR TITLE
fix: add bounds checks in AAC RTP demuxer to prevent panic

### DIFF
--- a/format/rtspv2/demuxer.go
+++ b/format/rtspv2/demuxer.go
@@ -226,14 +226,26 @@ func (client *RTSPClient) handleAudio(content []byte) ([]*av.Packet, bool) {
 			duration = time.Duration(20) * time.Millisecond
 			retmap = client.appendAudioPacket(retmap, nal, duration)
 		case av.AAC:
+			if len(nal) < 2 {
+				break
+			}
 			auHeadersLength := uint16(0) | (uint16(nal[0]) << 8) | uint16(nal[1])
 			auHeadersCount := auHeadersLength >> 4
 			framesPayloadOffset := 2 + int(auHeadersCount)<<1
+			if framesPayloadOffset > len(nal) {
+				break
+			}
 			auHeaders := nal[2:framesPayloadOffset]
 			framesPayload := nal[framesPayloadOffset:]
 			for i := 0; i < int(auHeadersCount); i++ {
+				if len(auHeaders) < 2 {
+					break
+				}
 				auHeader := uint16(0) | (uint16(auHeaders[0]) << 8) | uint16(auHeaders[1])
 				frameSize := auHeader >> 3
+				if int(frameSize) > len(framesPayload) {
+					break
+				}
 				frame := framesPayload[:frameSize]
 				auHeaders = auHeaders[2:]
 				framesPayload = framesPayload[frameSize:]


### PR DESCRIPTION
```
 panic: runtime error: slice bounds out of range [:4624] with capacity 1292

goroutine 10714598 [running]:
github.com/deepch/vdk/format/rtspv2.(*RTSPClient).RTPDemuxer(0xc0004d2a00, 0xc0002d6240?)
        github.com/deepch/vdk@v0.0.27/format/rtspv2/client.go:815 +0x247b
github.com/deepch/vdk/format/rtspv2.(*RTSPClient).startStream(0xc0004d2a00)
        github.com/deepch/vdk@v0.0.27/format/rtspv2/client.go:314 +0x53c
created by github.com/deepch/vdk/format/rtspv2.Dial in goroutine 68
        github.com/deepch/vdk@v0.0.27/format/rtspv2/client.go:243 +0x1905 
```   
This happens in a goroutine spawned by `Dial`, so the caller cannot
recover from it — the panic kills the entire process.

Add bounds checks before slicing in the `case av.AAC` branch:

1. Validate `framesPayloadOffset` does not exceed `len(nal)`
2. Validate `len(auHeaders) >= 2` before reading AU-header bytes
3. Validate `frameSize` does not exceed `len(framesPayload)`

Malformed packets are silently skipped instead of crashing.